### PR TITLE
@alloy: Prettify nav/logo

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
 <body>
 
 <header class="navigation">
-  <%= render(partial: '/shared/albers/svgs/mark')  %>
+  <%=link_to render(partial: '/shared/albers/svgs/mark'), '/' %>
   <ul>
     <li> <%= link_to 'Anthology', "/" %></li>
   </ul>


### PR DESCRIPTION
Minor tweak for albers nav styling

was
![image](https://cloud.githubusercontent.com/assets/197336/8940731/6b2d4b08-3539-11e5-805d-5c0c0771aff1.png)

now

![image](https://cloud.githubusercontent.com/assets/197336/8940724/65091388-3539-11e5-884d-e67d5d0b0285.png)
